### PR TITLE
fix(parse): handle no zero in _readString

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -95,7 +95,7 @@ function _readString(buffer: ArrayBuffer, offset: number, size: number) {
   const view = new Uint8Array(buffer, offset, size);
   const i = view.indexOf(0);
   const td = new TextDecoder();
-  return td.decode(view.slice(0, i));
+  return td.decode(i >= 0 ? view.slice(0, i) : view);
 }
 
 function _readNumber(buffer: ArrayBuffer, offset: number, size: number) {


### PR DESCRIPTION
(Sorry for no repro or tests, but I noticed this bug which should be simple to fix)

`view.indexOf(0)` could return `-1` if there's no `0`, e.g. if the entire `Uint8Array` is filled up. If it's `-1`, `view.slice(0, i)` would be incorrect because it removes the last item in the `Uint8Array`.

In this PR, if `-1` is found, we don't slice at all. And use the original `view` instead. I found this bug causing the `tarFile.name` to be missing the last character otherwise, e.g. `.../pkg/package.jso` (missing `n`)

