### PR TITLE
fix: return `ParsedTarFileItem` type after parsing

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -1,6 +1,6 @@
-import type { ParsedTarFileItem, TarFileItem } from "./types";
+import type { ParsedTarFileItem } from "./types";
 
-export function parseTar(data: ArrayBuffer | Uint8Array): TarFileItem[] {
+export function parseTar(data: ArrayBuffer | Uint8Array): ParsedTarFileItem[] {
   const buffer = (data as Uint8Array).buffer || data;
 
   const files: ParsedTarFileItem[] = [];
@@ -78,7 +78,7 @@ export function parseTar(data: ArrayBuffer | Uint8Array): TarFileItem[] {
 export async function parseTarGzip(
   data: ArrayBuffer | Uint8Array,
   opts: { compression?: CompressionFormat } = {},
-): Promise<TarFileItem[]> {
+): Promise<ParsedTarFileItem[]> {
   const stream = new ReadableStream({
     start(controller) {
       controller.enqueue(new Uint8Array(data));


### PR DESCRIPTION
The return type of `parseTar` and `parseTarGzip` should be using `ParsedTarFileItem` as that's what being computed in the functions:

https://github.com/unjs/nanotar/blob/c1247bdec97163b487c8ca55003e291dfea755ab/src/parse.ts#L3-L6

https://github.com/unjs/nanotar/blob/c1247bdec97163b487c8ca55003e291dfea755ab/src/parse.ts#L75

