### PR TITLE
feat(parse)!: support extended item types and headers

### DIFF
--- a/src/item-types.ts
+++ b/src/item-types.ts
@@ -1,0 +1,37 @@
+// prettier-ignore
+export type TarFileItemType = "file" | "hardLink" | "symbolicLink" | "characterDevice" | "blockDevice" | "directory" | "fifo" | "contiguousFile" | "globalExtendedHeader" | "extendedHeader" | "solarisAcl" | "gnuDirectory" | "gnuInodeMetadata" | "gnuLongLinkName" | "gnuLongFileName" | "gnuMultiVolume" | "gnuOldLongFileName" | "gnuSparseFile" | "solarisVolumeLabel" | "solarisOldExtendedHeader" | "gnuExtendedSparse";
+
+// prettier-ignore
+export type TarFileItemTypeValue = "0" | "1" | "2" | "3" | "4" | "5" | "6" | "7" | "g" | "x" | "A" | "D" | "I" | "K" | "L" | "M" | "N" | "S" | "V" | "X" | "E";
+
+// prettier-ignore
+export const tarItemTypeMap = {
+  // Standard
+  "0": "file",                    // Regular file
+  "1": "hardLink",                // Hard link (meta)
+  "2": "symbolicLink",            // Symbolic link (meta)
+  "3": "characterDevice",         // Character device (meta)
+  "4": "blockDevice",             // Block device (meta)
+  "5": "directory",               // Directory (meta)
+  "6": "fifo",                    // Named pipe (FIFO) (meta)
+  "7": "contiguousFile",          // Contiguous file (rarely used, mostly for older systems)
+
+  // Extended headers
+  "g": "globalExtendedHeader",    // Global extended header (meta)
+  "x": "extendedHeader",          // Extended header for the next file (meta)
+
+  // GNU tar
+  "D": "gnuDirectory",             // GNU directory metadata (meta)
+  "I": "gnuInodeMetadata",         // GNU inode metadata
+  "K": "gnuLongLinkName",          // GNU long link name
+  "L": "gnuLongFileName",          // GNU long file name
+  "N": "gnuOldLongFileName",       // GNU long file name (old)
+  "M": "gnuMultiVolume",           // Multi-volume archive entry
+  "S": "gnuSparseFile",            // Sparse file (for files with holes)
+  "E": "gnuExtendedSparse",         // Extended sparse file (used in GNU tar for large sparse files)
+
+  // Solaris tar
+  "A": "solarisAcl",               // Solaris access control list
+  "V": "solarisVolumeLabel",       // Solaris volume label (meta)
+  "X": "solarisOldExtendedHeader", // Deprecated extended header format (meta)
+} as const satisfies Record<TarFileItemTypeValue, TarFileItemType>;

--- a/src/item-types.ts
+++ b/src/item-types.ts
@@ -28,7 +28,7 @@ export const tarItemTypeMap = {
   "N": "gnuOldLongFileName",       // GNU long file name (old)
   "M": "gnuMultiVolume",           // Multi-volume archive entry
   "S": "gnuSparseFile",            // Sparse file (for files with holes)
-  "E": "gnuExtendedSparse",         // Extended sparse file (used in GNU tar for large sparse files)
+  "E": "gnuExtendedSparse",        // Extended sparse file (used in GNU tar for large sparse files)
 
   // Solaris tar
   "A": "solarisAcl",               // Solaris access control list

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,9 @@
+import type { TarFileItemType } from "./item-types";
+
+export type { TarFileItemType, TarFileItemTypeValue } from "./item-types";
+
+// ------------ Create ------------
+
 export type TarFileItem<DataT = Uint8Array> = {
   /**
    * File name
@@ -17,11 +23,13 @@ export type TarFileItem<DataT = Uint8Array> = {
   attrs?: TarFileAttrs;
 };
 
+// ------------ Parsed ------------
+
 export interface ParsedTarFileItem extends TarFileItem {
   /**
-   * The type of file system element. It can be `"file"`, `"directory"` or an operating system specific numeric code.
+   * The type of file system element. It is usually `"file"` or `"directory"`.
    */
-  type: "file" | "directory" | number;
+  type: TarFileItemType | undefined;
 
   /**
    * The size of the file in bytes.
@@ -35,6 +43,8 @@ export interface ParsedTarFileItem extends TarFileItem {
 }
 
 export type ParsedTarFileItemMeta = Omit<ParsedTarFileItem, "data" | "text">;
+
+// ------------ Attrs ------------
 
 export interface TarFileAttrs {
   /**

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -86,7 +86,7 @@ describe("parse", () => {
     const formats = ["gnu", "pax", "ustar", "v7"];
 
     for (const format of formats) {
-      it.skipIf(format === "pax")(`parseTar (${format})`, async () => {
+      it(`parseTar (${format})`, async () => {
         const blob = await readFile(
           new URL(`fixtures/out/${format}.tar`, import.meta.url),
         );


### PR DESCRIPTION
This PR improves parser's file.type` with extended possible item types (normalized to human friendly type codes) also implements basic support for extended attrs to skip special pax entries.

Breaking change: types are updated.

related to #29