### PR TITLE
fix: parse uid/gid as octal numbers per POSIX tar spec

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -54,10 +54,10 @@ export function parseTar<
     const mode = _readString(buffer, offset + 100, 8).trim();
 
     // File uid (offset: 108 - length: 8)
-    const uid = Number.parseInt(_readString(buffer, offset + 108, 8));
+    const uid = _readNumber(buffer, offset + 108, 8);
 
     // File gid (offset: 116 - length: 8)
-    const gid = Number.parseInt(_readString(buffer, offset + 116, 8));
+    const gid = _readNumber(buffer, offset + 116, 8);
 
     // File size (offset: 124 - length: 12)
     const size = _readNumber(buffer, offset + 124, 12);


### PR DESCRIPTION
Fixes #40

## Problem

The POSIX tar specification stores `uid` and `gid` fields as octal ASCII strings. The code was using `Number.parseInt()` which defaults to base 10, causing values like `01751` (decimal 1001) to be parsed as 1751.

## Fix

Replaced `Number.parseInt(_readString(...))` with `_readNumber(...)` for both uid and gid fields. `_readNumber` already correctly parses with radix 8, matching the behavior used for `size` and `mtime` fields.

```diff
- const uid = Number.parseInt(_readString(buffer, offset + 108, 8));
+ const uid = _readNumber(buffer, offset + 108, 8);

- const gid = Number.parseInt(_readString(buffer, offset + 116, 8));
+ const gid = _readNumber(buffer, offset + 116, 8);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of uid/gid field parsing in TAR archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->