### PR TITLE
fix: parse uid/gid as octal to match TAR format specification (#40)

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -54,10 +54,10 @@ export function parseTar<
     const mode = _readString(buffer, offset + 100, 8).trim();
 
     // File uid (offset: 108 - length: 8)
-    const uid = Number.parseInt(_readString(buffer, offset + 108, 8));
+    const uid = _readNumber(buffer, offset + 108, 8);
 
     // File gid (offset: 116 - length: 8)
-    const gid = Number.parseInt(_readString(buffer, offset + 116, 8));
+    const gid = _readNumber(buffer, offset + 116, 8);
 
     // File size (offset: 124 - length: 12)
     const size = _readNumber(buffer, offset + 124, 12);


### PR DESCRIPTION
### 🔗 Linked issue

Closes #40

### 📝 Description

TAR format stores uid and gid as octal-encoded ASCII strings, but `parse.ts` reads them using `Number.parseInt()` **without the radix parameter**. This defaults to decimal parsing (with auto-detect for leading zeros), which produces incorrect values.

**Example:** A uid of `1001` (decimal) is stored as `"001751"` in TAR (octal). The current code does `Number.parseInt("001751")` → `1751` (wrong). It should do `Number.parseInt("001751", 8)` → `1001` (correct).

Meanwhile, `_readNumber()` already correctly uses `Number.parseInt(str, 8)` for size and mtime fields. The uid/gid fields were inconsistent.

### Fix

Replace `Number.parseInt(_readString(...))` with `_readNumber(...)` for both uid and gid, matching the existing pattern used for size and mtime.

```diff
- const uid = Number.parseInt(_readString(buffer, offset + 108, 8));
+ const uid = _readNumber(buffer, offset + 108, 8);

- const gid = Number.parseInt(_readString(buffer, offset + 116, 8));
+ const gid = _readNumber(buffer, offset + 116, 8);
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy of user and group identifier parsing in TAR archives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->