### PR TITLE
fix: always emit the tar end-of-archive marker

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -42,10 +42,15 @@ export function createTar(
       tarDataSize += 512;
     }
   }
-  let bufSize = 10_240 * Math.trunc(tarDataSize / 10_240);
-  if (tarDataSize % 10_240) {
-    bufSize += 10_240;
-  }
+  // Reserve at least two 512-byte zero blocks after the data for the
+  // end-of-archive marker (the tar format requires the archive to end with two
+  // consecutive zero blocks), then round up to a full 10_240-byte record. The
+  // ArrayBuffer is zero-initialized, so the trailing slack forms the marker.
+  // The `+ 1024` matters when `tarDataSize` is already a multiple of 10_240
+  // (no slack would be added otherwise, leaving the archive with no marker at
+  // all; strict readers such as pnpm reject that) or exactly 512 short of a
+  // record (a single zero block instead of the required two).
+  const bufSize = 10_240 * Math.ceil((tarDataSize + 1024) / 10_240);
   const buffer = new ArrayBuffer(bufSize);
 
   let offset = 0;

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
-import { createTarGzip, type TarFileItem } from "../src/index.ts";
+import { createTar, createTarGzip, parseTar, type TarFileItem } from "../src/index.ts";
 
 const mtime = 1_700_000_000_000;
 
@@ -33,5 +33,35 @@ describe("create", () => {
       -rw-rw-r-- foo/bar.txt
        "
     `);
+  });
+});
+
+describe("end-of-archive marker", () => {
+  // A tar archive must end with two 512-byte all-zero blocks.
+  const hasMarker = (tar: Uint8Array) =>
+    tar.length >= 1024 && tar.length % 512 === 0 && tar.subarray(-1024).every((b) => b === 0);
+
+  it("always emits the marker, including on 10240-byte record boundaries", () => {
+    // Sweep 20 consecutive block counts so the packed size hits every
+    // 512-aligned residue mod 10240, including the exact-multiple case (which
+    // regressed to no marker) and the 512-short case (only a single block).
+    for (let blocks = 1; blocks <= 20; blocks++) {
+      const data = new Uint8Array(blocks * 512).fill(0x41);
+      const tar = createTar([{ name: "a.bin", data }]);
+      expect(hasMarker(tar), `size ${tar.length}`).toBe(true);
+      // ...and the archive still reads back intact (name and payload).
+      const [entry] = parseTar(tar);
+      expect(entry!.name).toBe("a.bin");
+      expect(entry!.data).toEqual(data);
+    }
+  });
+
+  it("returns a valid empty archive for an empty file list", () => {
+    // Previously this returned a zero-length buffer, which is not a valid tar
+    // stream; now it is a single all-zero record (marker only, no entries).
+    const tar = createTar([]);
+    expect(tar.length).toBe(10_240);
+    expect(tar.every((b) => b === 0)).toBe(true);
+    expect(parseTar(tar)).toEqual([]);
   });
 });


### PR DESCRIPTION
Fixes #71.

`createTar` sized its output buffer by rounding the packed data up to a full 10240-byte record, relying on the zero-filled slack to form the mandatory end-of-archive marker (two 512-byte zero blocks):

```js
let bufSize = 10_240 * Math.trunc(tarDataSize / 10_240)
if (tarDataSize % 10_240) bufSize += 10_240
```

When `tarDataSize` was already an exact multiple of 10240, no slack was added (`bufSize === tarDataSize`), so the archive had **no marker at all**; when it was exactly 512 bytes short of a record, only a single zero block was emitted instead of the required two. Since every entry is 512-aligned, ~1 in 20 archives lands on one of those boundaries.

Lenient readers (GNU/BSD `tar`, `gzip -t`) tolerate a missing marker, but strict ones reject it. `pnpm` fails to install a marker-less tarball (verified; the single-block case it happens to accept, but it still violates the tar format):

```
ERR_PNPM_TARBALL_EXTRACT  Invalid checksum for TAR header at offset <size>. Expected 0, got NaN
```

### Change
Reserve at least two zero blocks before rounding up to a record:

```js
const bufSize = 10_240 * Math.ceil((tarDataSize + 1024) / 10_240)
```

This is a **no-op for archives that already had a valid marker** (adding 1024 doesn't cross into a new record unless the old slack was `< 1024`, i.e. exactly the two broken cases).

One behavior change to be aware of: `createTar([])` previously returned a **zero-length buffer**, which is not a valid tar stream; it now returns a single all-zero 10240-byte record (a valid empty archive). Covered by a test.

### Tests
Added to `test/create.test.ts`:
- a sweep over a full record of packed sizes (covering the `0` and `9728` residues) asserting the marker is always present and the archive round-trips through `parseTar` with intact payloads;
- the empty-input case above.

The sweep fails on `main` and passes with this change. `pnpm lint` and the existing suite pass.

A standalone reproduction (deterministic + an end-to-end `pnpm install` failure) is here: https://github.com/why-reproductions-are-required/nanotar-missing-end-of-archive-marker


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TAR archive size handling to consistently include the required end-of-archive marker.
  * Fixed edge cases around exact record-boundary sizes so generated archives remain well-formed.
* **Tests**
  * Added coverage to validate trailing zero blocks (end-of-archive marker) across many archive sizes and boundary scenarios.
  * Verified generated TAR streams parse correctly and preserve expected entry data and naming.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->