### PR TITLE
fix(create): emit GNU L header for filenames >100 bytes

### DIFF
--- a/src/create.ts
+++ b/src/create.ts
@@ -36,6 +36,15 @@ export function createTar(
   // Create data buffer
   let tarDataSize = 0;
   for (let i = 0; i < files.length; i++) {
+    // GNU long filename header (L typeflag) when name exceeds 100 bytes
+    const nameLen = new TextEncoder().encode(_files[i]!.name).length;
+    if (nameLen > 100) {
+      const longDataSize = nameLen + 1; // +1 for null terminator
+      tarDataSize += 512 + 512 * Math.trunc(longDataSize / 512);
+      if (longDataSize % 512) {
+        tarDataSize += 512;
+      }
+    }
     const size = _files[i]!.data?.length ?? 0;
     tarDataSize += 512 + 512 * Math.trunc(size / 512);
     if (size % 512) {
@@ -52,6 +61,41 @@ export function createTar(
 
   for (const file of _files) {
     const isDir = !file.data;
+
+    // -- GNU long filename header (L typeflag) --
+    const nameBytes = new TextEncoder().encode(file.name);
+    if (nameBytes.length > 100) {
+      const longDataSize = nameBytes.length + 1; // +1 for null terminator
+      const longDataBlocks = 512 * Math.trunc(longDataSize / 512) + (longDataSize % 512 ? 512 : 0);
+
+      // Long name header fields
+      _writeString(buffer, "././@LongName", offset, 100);
+      _writeString(buffer, _leftPad("0", 7), offset + 100, 8); // mode
+      _writeString(buffer, _leftPad("0", 7), offset + 108, 8); // uid
+      _writeString(buffer, _leftPad("0", 7), offset + 116, 8); // gid
+      _writeString(buffer, _leftPad(longDataSize.toString(8), 11), offset + 124, 12); // size
+      _writeString(buffer, _leftPad("0", 11), offset + 136, 12); // mtime
+      _writeString(buffer, "L", offset + 156, 1); // typeflag
+      _writeString(buffer, "ustar", offset + 257, 6);
+      _writeString(buffer, "00", offset + 263, 2);
+
+      // Checksum
+      _writeString(buffer, "        ", offset + 148, 8);
+      const longHeader = new Uint8Array(buffer, offset, 512);
+      let longChksum = 0;
+      for (let i = 0; i < 512; i++) {
+        longChksum += longHeader[i]!;
+      }
+      _writeString(buffer, longChksum.toString(8), offset + 148, 8);
+
+      // Long name data (name + null, padded to 512)
+      const longDataView = new Uint8Array(buffer, offset + 512, longDataBlocks);
+      longDataView.set(nameBytes, 0);
+      longDataView[nameBytes.length] = 0; // null terminator
+      // rest is already zero-filled
+
+      offset += 512 + longDataBlocks;
+    }
 
     // -- Header --
     // File name (offset: 0 - length: 100)

--- a/test/create.test.ts
+++ b/test/create.test.ts
@@ -1,6 +1,6 @@
 import { execSync } from "node:child_process";
 import { describe, expect, it } from "vitest";
-import { createTarGzip, type TarFileItem } from "../src/index.ts";
+import { createTar, createTarGzip, parseTar, type TarFileItem } from "../src/index.ts";
 
 const mtime = 1_700_000_000_000;
 
@@ -33,5 +33,28 @@ describe("create", () => {
       -rw-rw-r-- foo/bar.txt
        "
     `);
+  });
+
+  it("createTar emits GNU L header for filenames >100 bytes", () => {
+    const longName =
+      "a/very/long/path/that/definitely/exceeds/one/hundred/characters/in/total/length/yes/indeed/this/is/file.txt";
+    expect(longName.length).toBeGreaterThan(100);
+
+    const tar = createTar([{ name: longName, data: "hello", attrs: { mtime } }]);
+
+    // Roundtrip: parseTar should recover the full name
+    const parsed = parseTar(tar);
+    expect(parsed).toHaveLength(1);
+    expect(parsed[0]!.name).toBe(longName);
+    expect(parsed[0]!.size).toBe(5);
+  });
+
+  it("createTar long filename is readable by system tar", () => {
+    const longName =
+      "another/very/long/path/that/definitely/exceeds/one/hundred/characters/in/total/length/yes/indeed/file.txt";
+    const tar = createTar([{ name: longName, data: "content", attrs: { mtime } }]);
+
+    const listing = execSync("tar -tf-", { input: tar }).toString().trim();
+    expect(listing).toBe(longName);
   });
 });


### PR DESCRIPTION
## Summary

Fixes #29.

`createTar` silently truncated filenames longer than 100 bytes at the name field boundary (`_writeString(buffer, file.name, offset, 100)`), producing archives with shortened paths. `parseTar` already handles the GNU `L` typeflag (lines 94-101 in `parse.ts`), so the fix is to emit the `L` header before the file entry when the name exceeds 100 bytes.

### Changes

- **`src/create.ts`**: When `file.name` exceeds 100 bytes, emit a GNU long filename header (`././@LongName`, typeflag `L`) with the full name as data, before the regular file header. Buffer size calculation accounts for the extra header + data blocks.
- **`test/create.test.ts`**: 2 regression tests — roundtrip (`createTar` → `parseTar` recovers full 107-char name) and system `tar -tf` reads the full name.

### Verification

```
name length: 107
[file] a/very/long/path/that/definitely/exceeds/one/hundred/characters/in/total/length/yes/indeed/this/is/file.txt (5 bytes)
match: true
```

System `tar` reads the full name:
```
$ tar tvf nanotar-long.tar
-rw-rw-r--  0 1000   1000       11 Aug 13 21:04 a/very/long/path/that/definitely/exceeds/one/hundred/characters/in/total/length/yes/indeed/this/is/file.txt
```

- All 18 tests pass (16 existing + 2 new)
- Lint clean (`oxlint` + `oxfmt`)
- Pre-existing typecheck errors (`node:child_process` types) are unrelated — same errors on `main` before this change

#### Test plan

- [x] `npx vitest run` — 18/18 pass
- [x] `pnpm lint` — 0 warnings, 0 errors
- [x] Roundtrip: `createTar` → `parseTar` preserves full name
- [x] System `tar -tf` reads the full name
- [x] Short filenames (<100 bytes) unaffected — existing tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for creating TAR archives containing GNU long filenames.
  * Long filenames are preserved and remain accessible when archives are read by standard TAR tools.

* **Tests**
  * Added coverage confirming long filenames are correctly created, parsed, and read.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->