### PR TITLE
fix(parse): join the ustar `prefix` field into the file name

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -42,6 +42,17 @@ export function parseTar<
       break;
     }
 
+    // Ustar prefix (offset: 345 - length: 155)
+    // Paths longer than 100 bytes are split into `prefix` + "/" + `name` by ustar writers.
+    // Only trust the field when the ustar magic (offset: 257 - length: 6) is present, since
+    // older formats leave that area as padding.
+    if (_readString(buffer, offset + 257, 6).trim() === "ustar") {
+      const prefix = _readString(buffer, offset + 345, 155);
+      if (prefix.length > 0) {
+        name = `${prefix}/${name}`;
+      }
+    }
+
     // Long file-name handling
     if (nextExtendedHeader) {
       const longName = nextExtendedHeader.path || nextExtendedHeader.linkpath;

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -11,6 +11,63 @@ import { readFile } from "node:fs/promises";
 
 const mtime = 1_700_000_000_000;
 
+/** Writes an ASCII string into `buffer` at `offset`, NUL padded up to `size`. */
+function _writeString(buffer: Uint8Array, str: string, offset: number, size: number) {
+  const bytes = new TextEncoder().encode(str);
+  buffer.set(bytes.subarray(0, size), offset);
+}
+
+/**
+ * Builds a raw ustar archive so header fields can be exercised directly.
+ *
+ * `createTar` always writes the path into the 100-byte `name` field, so it cannot
+ * produce the `prefix` split that ustar writers (GNU tar, npm pack, ...) emit for
+ * long paths.
+ */
+function ustarTar(
+  entries: { name: string; prefix?: string; type?: string; magic?: string; data?: string }[],
+) {
+  const blocks: Uint8Array[] = [];
+  for (const entry of entries) {
+    const data = new TextEncoder().encode(entry.data ?? "");
+    const header = new Uint8Array(512);
+    _writeString(header, entry.name, 0, 100);
+    _writeString(header, "0000644\0", 100, 8); // mode
+    _writeString(header, "0000000\0", 108, 8); // uid
+    _writeString(header, "0000000\0", 116, 8); // gid
+    _writeString(header, `${data.length.toString(8).padStart(11, "0")}\0`, 124, 12); // size
+    _writeString(header, `${(mtime / 1000).toString(8).padStart(11, "0")}\0`, 136, 12);
+    header.fill(32, 148, 156); // checksum placeholder (spaces)
+    _writeString(header, entry.type ?? "0", 156, 1);
+    _writeString(header, entry.magic ?? "ustar\0", 257, 6);
+    _writeString(header, "00", 263, 2); // version
+    _writeString(header, entry.prefix ?? "", 345, 155);
+
+    // Checksum is the sum of all header bytes with the field itself read as spaces
+    const checksum = header.reduce((sum, byte) => sum + byte, 0);
+    _writeString(header, `${checksum.toString(8).padStart(6, "0")}\0 `, 148, 8);
+
+    blocks.push(header, data, new Uint8Array((512 - (data.length % 512)) % 512));
+  }
+  blocks.push(new Uint8Array(1024)); // end-of-archive marker
+
+  const size = blocks.reduce((total, block) => total + block.length, 0);
+  const tar = new Uint8Array(size);
+  let offset = 0;
+  for (const block of blocks) {
+    tar.set(block, offset);
+    offset += block.length;
+  }
+  return tar;
+}
+
+/** Encodes a single `<len> <key>=<value>\n` pax extended header record. */
+function paxRecord(key: string, value: string) {
+  const body = ` ${key}=${value}\n`;
+  const len = body.length + String(body.length).length;
+  return `${len}${body}`;
+}
+
 const fixture: TarFileItem<any>[] = [
   { name: "hello.txt", data: "Hello World!", attrs: { mtime } },
   { name: "test", attrs: { mtime, uid: 1001, gid: 1001 } },
@@ -70,6 +127,37 @@ describe("path traversal prevention", () => {
     const tar = createTar([{ name: "./../../../etc/passwd", data: "malicious" }]);
     const files = parseTar(tar);
     expect(files[0]!.name).toBe("./etc/passwd");
+  });
+});
+
+describe("ustar prefix field", () => {
+  // Paths longer than 100 bytes are split by ustar writers into
+  // `prefix` (offset 345, 155 bytes) + "/" + `name` (offset 0, 100 bytes).
+  const longDir = "package/node_modules/@scope/some-rather-long-package-name/dist/esm/internal";
+  const longName = "a-file-with-a-name-that-pushes-the-path-past-one-hundred-bytes.mjs";
+
+  it("joins prefix and name back into the full path", () => {
+    const tar = ustarTar([{ prefix: longDir, name: longName }]);
+    expect(parseTar(tar)[0]!.name).toBe(`${longDir}/${longName}`);
+  });
+
+  it("ignores the prefix area when the ustar magic is absent", () => {
+    // v7 headers leave offset 345 as padding, so any bytes there are not a path prefix.
+    const tar = ustarTar([{ prefix: longDir, name: longName, magic: "" }]);
+    expect(parseTar(tar)[0]!.name).toBe(longName);
+  });
+
+  it("sanitizes traversal sequences coming from the prefix", () => {
+    const tar = ustarTar([{ prefix: "../../etc", name: "passwd" }]);
+    expect(parseTar(tar)[0]!.name).toBe("etc/passwd");
+  });
+
+  it("prefers an extended header path over the prefix", () => {
+    const tar = ustarTar([
+      { name: "././@PaxHeader", type: "x", data: paxRecord("path", "pax/path.txt") },
+      { prefix: longDir, name: longName },
+    ]);
+    expect(parseTar(tar)[0]!.name).toBe("pax/path.txt");
   });
 });
 


### PR DESCRIPTION
Fixes #38, and the `[file] Bar.vue` / `[directory] .../components/` output in #29.

### The bug

Paths longer than 100 bytes don't fit the ustar `name` field, so writers split them across the 155-byte `prefix` field (offset 345) and `name` (offset 0), joined by `/`. `parseTar` only reads `name`, so those entries come back as bare basenames with their directory dropped.

Reproducing #38 with the package from the report — `@libsql/client-wasm@0.15.1` has 20 entries, 5 of them long enough to be split:

```js
const files = await parseTarGzip(await readFile("client-wasm-0.15.1.tgz"), { metaOnly: true });
files.filter((f) => !f.name.startsWith("package/")).length;
// before: 5     after: 0

files.find((f) => f.name.endsWith("sqlite3-bundler-friendly.mjs")).name;
// before: "sqlite3-bundler-friendly.mjs"
// after:  "package/node_modules/@libsql/libsql-wasm-experimental/sqlite-wasm/jswasm/sqlite3-bundler-friendly.mjs"
```

The five files collide with the same basenames elsewhere in the archive and appear to sit at the archive root, so anything extracting to disk writes them to the wrong place.

### The fix

Read `prefix` and join it back onto `name`, guarded on the ustar magic at offset 257 — v7 headers leave that area as padding, so a non-empty prefix there is not a path. The joined name still goes through `_sanitizePath`, and pax/GNU long-name headers keep priority, so this only changes entries that were previously losing their directory.

Existing fixtures don't cover it: the `ustar.tar` fixture only holds short paths (`--format=ustar` skips the `long/` directory), and `createTar` always writes to `name`, so a raw ustar writer is needed to exercise the field. Added a small `ustarTar` header builder to `test/parse.test.ts` and four cases: the prefix join, the v7 guard, prefix traversal sanitization, and pax precedence. The first and third fail on `main`.

`pnpm lint` clean, `vitest run` → 20 passed. `test:types` has 5 pre-existing `@types/node` errors on `main`, unchanged by this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TAR archive parsing for long paths split across Ustar header fields.
  * Added path safety handling for Ustar prefixes.
  * Ensured extended PAX paths take precedence when both formats provide a path.

* **Tests**
  * Added coverage for Ustar path handling, invalid prefixes, traversal sanitization, and PAX path precedence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->